### PR TITLE
Added ```extend_dataset``` example.

### DIFF
--- a/sas_code_node/extend_dataset/README.md
+++ b/sas_code_node/extend_dataset/README.md
@@ -1,0 +1,8 @@
+This example SAS code shows how to preprocess inut data in terms not columns
+(as in ```update_metdata``` example) but rows. It simply doubles the input 
+dataset in terms of rows. Of course the example is very easy but the data step
+included can (and should) be modified to create more complex transformations.
+
+**Instructions:** In Model Studio, add a SAS Code node to your pipeline, 
+then open it and paste snippets of this code as needed into the Training Code 
+pane, then save and close the node. 

--- a/sas_code_node/extend_dataset/extend_dataset.sas
+++ b/sas_code_node/extend_dataset/extend_dataset.sas
@@ -1,0 +1,15 @@
+
+/* Training Code */
+/* Let the output data contain the doubled data from the input data set */
+/* ```dm_data``` in terms of rows. */
+
+/* training code */
+data &dm_output_data;
+    set &dm_data &dm_data;
+run;
+%dmcas_register(dataset=&DM_OUTPUT_DATA, type=cas);
+
+
+
+/* Scoring Code */
+/* Nothing else is required */


### PR DESCRIPTION
Adding an example how to extend input dataset in terms of rows rather then columns. 