### PR TITLE
sf_onehotvars_sklearn_randomforest - drop command fix

### DIFF
--- a/open_source_code_node/simple_forest/sf_onehotvars_sklearn_randomforest.py
+++ b/open_source_code_node/simple_forest/sf_onehotvars_sklearn_randomforest.py
@@ -12,7 +12,7 @@ fullX_enc = pd.get_dummies(fullX, columns=dm_class_input, drop_first=True)
 
 # Training data
 X_enc = fullX_enc[fullX_enc[dm_partitionvar] == dm_partition_train_val]
-X_enc = X_enc.drop(dm_partitionvar, 1)
+X_enc = X_enc.drop(dm_partitionvar, axis=1)
 
 # Labels
 y = dm_traindf[dm_dec_target]
@@ -28,5 +28,5 @@ varimp = pd.DataFrame(list(zip(X_enc, dm_model.feature_importances_)), columns=[
 varimp.to_csv(dm_nodedir + '/rpt_var_imp.csv', index=False)
 
 # Score full data
-fullX_enc = fullX_enc.drop(dm_partitionvar, 1)
+fullX_enc = fullX_enc.drop(dm_partitionvar, axis=1)
 dm_scoreddf = pd.DataFrame(dm_model.predict_proba(fullX_enc), columns=['P_DEFAULT_NEXT_MONTH0', 'P_DEFAULT_NEXT_MONTH1'])


### PR DESCRIPTION
Fixing issue with drop() command - newer versions of Pandas no longer support axis as a positional parameter, so you have to explicitly say "axis=1".  